### PR TITLE
Preserve scroll position when new output arrives

### DIFF
--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -557,6 +557,14 @@ export class Terminal implements ITerminalCore {
     // preserve selection when new data arrives. Selection is cleared by user actions
     // like clicking or typing, not by incoming data.
 
+    // Save scroll state before writing.  viewportY is relative to the
+    // bottom, so if new lines push content into scrollback we need to
+    // bump viewportY by the same amount to keep the viewport locked on
+    // the same content.
+    const savedViewportY = this.viewportY;
+    const savedScrollback = savedViewportY > 0
+      ? this.wasmTerm!.getScrollbackLength() : 0;
+
     // Write directly to WASM terminal (handles VT parsing internally)
     this.wasmTerm!.write(data);
 
@@ -575,9 +583,14 @@ export class Terminal implements ITerminalCore {
     // Invalidate link cache (content changed)
     this.linkDetector?.invalidateCache();
 
-    // Phase 2: Auto-scroll to bottom on new output (xterm.js behavior)
-    if (this.viewportY !== 0) {
-      this.scrollToBottom();
+    // If the user had scrolled up, adjust viewportY so the viewport
+    // stays locked on the same content instead of drifting as new
+    // scrollback lines are added.  Clamp to the current scrollback
+    // length in case old lines were dropped by the scrollback limit.
+    if (savedViewportY > 0) {
+      const newScrollback = this.wasmTerm!.getScrollbackLength();
+      const delta = newScrollback - savedScrollback;
+      this.viewportY = Math.min(savedViewportY + Math.max(0, delta), newScrollback);
     }
 
     // Check for title changes (OSC 0, 1, 2 sequences)


### PR DESCRIPTION
## Summary
- Stop `writeInternal()` from calling `scrollToBottom()` when the user has scrolled up
- Instead, adjust `viewportY` by the scrollback delta so the viewport stays locked on the same content
- Clamp `viewportY` to the current scrollback length to handle the edge case where old lines are dropped by the buffer limit
- Scrolling back to the bottom (`viewportY === 0`) resumes auto-follow naturally

## Test plan
- [ ] Run a slow command (e.g. `for i in $(seq 1 200); do echo "line $i"; sleep 1; done`)
- [ ] Scroll up while output is streaming — viewport should stay locked on the same lines
- [ ] Scroll back to the bottom — auto-follow should resume
- [ ] Run a fast command (e.g. `seq 1 10000`) — should still auto-scroll to the end
- [ ] Verify scrollback buffer overflow doesn't crash (viewportY clamped to scrollback length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)