### PR TITLE
feat: allow injecting an existing GhosttyTerminal into Terminal

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -2,7 +2,7 @@
  * xterm.js-compatible interfaces
  */
 
-import type { Ghostty } from './ghostty';
+import type { Ghostty, GhosttyTerminal } from './ghostty';
 
 export interface ITerminalOptions {
   cols?: number; // Default: 80
@@ -25,6 +25,22 @@ export interface ITerminalOptions {
   // Internal: Ghostty WASM instance (optional, for test isolation)
   // If not provided, uses the module-level instance from init()
   ghostty?: Ghostty;
+
+  /**
+   * Adopt an existing GhosttyTerminal instead of allocating a fresh one.
+   *
+   * When provided, `open()` skips wasm terminal creation and uses the injected
+   * terminal's buffer/scrollback/mode state directly. The caller retains
+   * ownership: `Terminal.dispose()` will NOT free the wasm terminal, and
+   * `Terminal.reset()` throws (call `free()` + `createTerminal()` yourself).
+   *
+   * When `cols`/`rows` are not provided, they default to the injected
+   * terminal's current dimensions.
+   *
+   * Used to persist terminal state across view lifetimes (e.g. keeping the
+   * buffer alive while the DOM renderer is unmounted and later remounted).
+   */
+  wasmTerm?: GhosttyTerminal;
 }
 
 export interface ITheme {

--- a/lib/terminal.test.ts
+++ b/lib/terminal.test.ts
@@ -10,7 +10,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import type { Terminal } from './terminal';
+import { Ghostty } from './ghostty';
+import { Terminal } from './terminal';
 import { createIsolatedTerminal } from './test-helpers';
 
 /**
@@ -3046,5 +3047,181 @@ describe('Synchronous open()', () => {
 
     wasmTerm2.free();
     term1.dispose();
+  });
+});
+
+describe('Injected wasmTerm (ITerminalOptions.wasmTerm)', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    if (typeof document !== 'undefined') {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    }
+  });
+
+  afterEach(() => {
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+      container = null!;
+    }
+  });
+
+  test('adopts injected wasmTerm without allocating a new one', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(80, 24);
+
+    const term = new Terminal({ ghostty, wasmTerm });
+    term.open(container!);
+
+    // The Terminal should have adopted the exact wasmTerm we passed in,
+    // not constructed a replacement.
+    expect(term.wasmTerm).toBe(wasmTerm);
+
+    term.dispose();
+    wasmTerm.free();
+  });
+
+  test('preserves buffer contents written before injection', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(80, 24);
+    wasmTerm.write('Hello, injected world!');
+
+    const term = new Terminal({ ghostty, wasmTerm });
+    term.open(container!);
+
+    const line = term.wasmTerm!.getLine(0);
+    expect(line).not.toBeNull();
+    expect(line![0].codepoint).toBe('H'.codePointAt(0)!);
+    expect(line![7].codepoint).toBe('i'.codePointAt(0)!);
+
+    term.dispose();
+    wasmTerm.free();
+  });
+
+  test('dispose() does not free injected wasmTerm', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(80, 24);
+    wasmTerm.write('survive me');
+
+    const term = new Terminal({ ghostty, wasmTerm });
+    term.open(container!);
+    term.dispose();
+
+    // wasmTerm must still be usable after the Terminal wrapper is gone.
+    expect(() => wasmTerm.write(' still here')).not.toThrow();
+    const line = wasmTerm.getLine(0);
+    expect(line).not.toBeNull();
+    expect(line![0].codepoint).toBe('s'.codePointAt(0)!);
+
+    wasmTerm.free();
+  });
+
+  test('state persists across dispose + new wrapper (the reattach case)', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(80, 24);
+    wasmTerm.write('persistent state');
+
+    // First wrapper: mount, then tear down the view.
+    const term1 = new Terminal({ ghostty, wasmTerm });
+    term1.open(container!);
+    term1.dispose();
+
+    // Second wrapper on the same wasmTerm: should see the original buffer.
+    const container2 = document.createElement('div');
+    document.body.appendChild(container2);
+    const term2 = new Terminal({ ghostty, wasmTerm });
+    term2.open(container2);
+
+    const line = term2.wasmTerm!.getLine(0);
+    expect(line).not.toBeNull();
+    expect(line![0].codepoint).toBe('p'.codePointAt(0)!);
+    expect(line![11].codepoint).toBe('s'.codePointAt(0)!); // "state"
+
+    term2.dispose();
+    container2.remove();
+    wasmTerm.free();
+  });
+
+  test('writes through the Terminal wrapper land in the injected wasmTerm', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(80, 24);
+
+    const term = new Terminal({ ghostty, wasmTerm });
+    term.open(container!);
+    term.write('from wrapper');
+
+    // Same buffer — read directly from the wasmTerm reference the caller holds.
+    const line = wasmTerm.getLine(0);
+    expect(line).not.toBeNull();
+    expect(line![0].codepoint).toBe('f'.codePointAt(0)!);
+
+    term.dispose();
+    wasmTerm.free();
+  });
+
+  test('reset() throws when wasmTerm was injected', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(80, 24);
+
+    const term = new Terminal({ ghostty, wasmTerm });
+    term.open(container!);
+
+    expect(() => term.reset()).toThrow(/not supported when a wasmTerm was injected/);
+
+    // wasmTerm should still be alive after the failed reset.
+    expect(() => wasmTerm.write('still alive')).not.toThrow();
+
+    term.dispose();
+    wasmTerm.free();
+  });
+
+  test('defaults cols/rows to injected wasmTerm dimensions', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(132, 43);
+
+    const term = new Terminal({ ghostty, wasmTerm });
+    expect(term.cols).toBe(132);
+    expect(term.rows).toBe(43);
+
+    term.open(container!);
+    // wasmTerm dimensions stay put when they match.
+    expect(wasmTerm.cols).toBe(132);
+    expect(wasmTerm.rows).toBe(43);
+
+    term.dispose();
+    wasmTerm.free();
+  });
+
+  test('explicit cols/rows override and resize the injected wasmTerm on open', async () => {
+    const ghostty = await Ghostty.load();
+    const wasmTerm = ghostty.createTerminal(80, 24);
+
+    const term = new Terminal({ ghostty, wasmTerm, cols: 100, rows: 30 });
+    expect(term.cols).toBe(100);
+    expect(term.rows).toBe(30);
+
+    term.open(container!);
+    expect(wasmTerm.cols).toBe(100);
+    expect(wasmTerm.rows).toBe(30);
+
+    term.dispose();
+    wasmTerm.free();
+  });
+
+  test('ownsWasmTerm=true (no injection) still frees on dispose', async () => {
+    // Regression check: the default allocation path must not be broken.
+    const term = await createIsolatedTerminal({ cols: 80, rows: 24 });
+    term.open(container!);
+    const wasmTermRef = term.wasmTerm!;
+    term.dispose();
+
+    // After dispose, the Terminal clears its wasmTerm field. We can't safely
+    // call methods on wasmTermRef because the underlying memory is freed —
+    // the assertion here is that dispose() went through the free path at all.
+    expect(term.wasmTerm).toBeUndefined();
+    // Sanity-check: holding the reference does not crash the test harness.
+    // (Calling methods on it would be use-after-free.)
+    expect(wasmTermRef).toBeDefined();
   });
 });

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -65,6 +65,9 @@ export class Terminal implements ITerminalCore {
   // Components (created on open())
   private ghostty?: Ghostty;
   public wasmTerm?: GhosttyTerminal; // Made public for link providers
+  /** Whether this Terminal owns (and must free) its wasmTerm. False when
+   *  wasmTerm was passed in via ITerminalOptions.wasmTerm. */
+  private ownsWasmTerm: boolean = true;
   public renderer?: CanvasRenderer; // Made public for FitAddon
   private inputHandler?: InputHandler;
   private selectionManager?: SelectionManager;
@@ -137,10 +140,18 @@ export class Terminal implements ITerminalCore {
     // Use provided Ghostty instance (for test isolation) or get module-level instance
     this.ghostty = options.ghostty ?? getGhostty();
 
+    // Adopt an injected wasm terminal if provided. The caller retains ownership
+    // (cleanupComponents() will skip free(), reset() throws). When cols/rows
+    // are not explicitly set, inherit them from the injected terminal.
+    if (options.wasmTerm) {
+      this.wasmTerm = options.wasmTerm;
+      this.ownsWasmTerm = false;
+    }
+
     // Create base options object with all defaults (excluding ghostty)
     const baseOptions = {
-      cols: options.cols ?? 80,
-      rows: options.rows ?? 24,
+      cols: options.cols ?? options.wasmTerm?.cols ?? 80,
+      rows: options.rows ?? options.wasmTerm?.rows ?? 24,
       cursorBlink: options.cursorBlink ?? false,
       cursorStyle: options.cursorStyle ?? 'block',
       theme: options.theme ?? {},
@@ -369,9 +380,22 @@ export class Terminal implements ITerminalCore {
       parent.setAttribute('aria-label', 'Terminal input');
       parent.setAttribute('aria-multiline', 'true');
 
-      // Create WASM terminal with current dimensions and config
-      const config = this.buildWasmConfig();
-      this.wasmTerm = this.ghostty!.createTerminal(this.cols, this.rows, config);
+      // Create WASM terminal with current dimensions and config.
+      //
+      // If a wasmTerm was injected via ITerminalOptions.wasmTerm, adopt it
+      // instead of allocating a fresh one. The resize-if-differs branch
+      // below only runs when the caller explicitly set cols/rows in the
+      // options alongside wasmTerm — the constructor's cols/rows default
+      // to the injected terminal's own dims, so in the common case the
+      // check is a no-op.
+      if (this.wasmTerm) {
+        if (this.wasmTerm.cols !== this.cols || this.wasmTerm.rows !== this.rows) {
+          this.wasmTerm.resize(this.cols, this.rows);
+        }
+      } else {
+        const config = this.buildWasmConfig();
+        this.wasmTerm = this.ghostty!.createTerminal(this.cols, this.rows, config);
+      }
 
       // Create canvas element
       this.canvas = document.createElement('canvas');
@@ -725,9 +749,26 @@ export class Terminal implements ITerminalCore {
 
   /**
    * Reset terminal state
+   *
+   * Frees the current wasm terminal and allocates a fresh one with the
+   * same dimensions and config. This is the xterm.js-compatible RIS-style
+   * full reset — user code calls `term.reset()` to wipe state.
+   *
+   * Throws when the wasm terminal was injected via ITerminalOptions.wasmTerm:
+   * reset() would have to free a buffer the caller owns, which silently
+   * breaks the ownership contract. Callers wanting to reset an externally
+   * owned wasmTerm should free() + createTerminal() + construct a new
+   * Terminal wrapper themselves.
    */
   reset(): void {
     this.assertOpen();
+
+    if (!this.ownsWasmTerm) {
+      throw new Error(
+        'Terminal.reset() is not supported when a wasmTerm was injected via ' +
+          'ITerminalOptions.wasmTerm. The caller owns the wasmTerm lifecycle.'
+      );
+    }
 
     // Free old WASM terminal and create new one
     if (this.wasmTerm) {
@@ -1276,9 +1317,13 @@ export class Terminal implements ITerminalCore {
       this.linkDetector = undefined;
     }
 
-    // Free WASM terminal
+    // Free WASM terminal — only if we own it. Injected wasmTerms
+    // (ITerminalOptions.wasmTerm) belong to the caller; they keep them alive
+    // across view lifetimes and are responsible for calling free() themselves.
     if (this.wasmTerm) {
-      this.wasmTerm.free();
+      if (this.ownsWasmTerm) {
+        this.wasmTerm.free();
+      }
       this.wasmTerm = undefined;
     }
 


### PR DESCRIPTION
## Summary

Adds `ITerminalOptions.wasmTerm` so callers can keep a `GhosttyTerminal` alive independently of the `Terminal` wrapper's lifetime. When provided:

- Constructor adopts the injected buffer instead of allocating; `cols`/`rows` default to the injected dims.
- `Terminal.dispose()` skips `free()` — the caller retains ownership.
- `Terminal.reset()` throws (would otherwise free a buffer the caller still holds).

Motivated by a terminal-emulator client that needs to preserve buffer state (scrollback, cursor, alt-screen, hyperlinks) across view-layer mount cycles — e.g. reparenting into a different DOM tree without wiping the terminal.

## Test plan
- [x] New `describe('Injected wasmTerm …')` block with 9 tests
- [x] Existing 143 tests still pass (152 total)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build:lib` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)