### PR TITLE
refactor(input): route every keydown through the Ghostty encoder

### DIFF
--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -742,6 +742,38 @@ describe('InputHandler', () => {
       expect(dataReceived[2]).toBe('\x1bOD');
       expect(dataReceived[3]).toBe('\x1bOC');
     });
+
+    // The per-keystroke encoder-option sync caches the last value and
+    // short-circuits when unchanged. This test makes sure mode *changes*
+    // do propagate — if the cache fails to invalidate, the second
+    // keystroke would emit the wrong sequence.
+    test('picks up DECCKM changes mid-session', () => {
+      let cursorApp = false;
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        (mode: number) => mode === 1 && cursorApp
+      );
+
+      simulateKey(container, createKeyEvent('ArrowUp', 'ArrowUp'));
+      expect(dataReceived[0]).toBe('\x1b[A');
+      dataReceived.length = 0;
+
+      cursorApp = true;
+      simulateKey(container, createKeyEvent('ArrowUp', 'ArrowUp'));
+      expect(dataReceived[0]).toBe('\x1bOA');
+      dataReceived.length = 0;
+
+      cursorApp = false;
+      simulateKey(container, createKeyEvent('ArrowUp', 'ArrowUp'));
+      expect(dataReceived[0]).toBe('\x1b[A');
+    });
   });
 
   describe('Function Keys', () => {
@@ -1190,6 +1222,49 @@ describe('InputHandler', () => {
       simulateKey(container, createKeyEvent('KeyV', 'v', { meta: true }));
 
       expect(dataReceived.length).toBe(0);
+    });
+  });
+
+  // Regression tests for the encoder-bypass removal. Two representative
+  // cases cover the two distinct code paths the old fast paths poisoned:
+  //
+  //   1. Shift+Enter — modifiers reach the encoder (the original bug class
+  //      that caught Shift+Home, Shift+F1, etc.; one test is enough).
+  //   2. Surrogate-pair emoji — multi-code-unit utf8 passes through
+  //      (covers both non-ASCII and non-BMP in one shot).
+  describe('Regression: encoder bypass removal', () => {
+    test('Shift+Enter differs from plain Enter', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        }
+      );
+
+      simulateKey(container, createKeyEvent('Enter', 'Enter'));
+      expect(dataReceived[0]).toBe('\r');
+
+      dataReceived.length = 0;
+      simulateKey(container, createKeyEvent('Enter', 'Enter', { shift: true }));
+      expect(dataReceived.length).toBe(1);
+      // Ghostty emits the modifyOtherKeys sequence for Shift+Enter by default.
+      expect(dataReceived[0]).toBe('\x1b[27;2;13~');
+    });
+
+    test('surrogate-pair emoji is emitted as UTF-8', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        }
+      );
+
+      simulateKey(container, createKeyEvent('KeyA', '😀'));
+      expect(dataReceived).toEqual(['😀']);
     });
   });
 });

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -207,6 +207,11 @@ export class InputHandler {
   private lastBeforeInputData: string | null = null;
   private lastBeforeInputTime = 0;
   private static readonly BEFORE_INPUT_IGNORE_MS = 100;
+  // Cache of encoder option values last pushed to the WASM encoder, so
+  // keystroke handling can skip the setOption WASM round-trip when nothing
+  // changed. `undefined` means "never synced"; any first query on a new
+  // handler will emit one setOption per option regardless of mode state.
+  private syncedEncoderOptions = new Map<KeyEncoderOption, boolean | number>();
 
   /**
    * Create a new InputHandler
@@ -321,6 +326,17 @@ export class InputHandler {
   }
 
   /**
+   * Push an encoder option value to WASM only if it differs from the last
+   * value we pushed. Terminal modes rarely change between keystrokes, so
+   * this saves two WASM round-trips per keystroke in the steady state.
+   */
+  private syncEncoderOption(option: KeyEncoderOption, value: boolean | number): void {
+    if (this.syncedEncoderOptions.get(option) === value) return;
+    this.encoder.setOption(option, value);
+    this.syncedEncoderOptions.set(option, value);
+  }
+
+  /**
    * Extract modifier flags from KeyboardEvent
    * @param event - KeyboardEvent
    * @returns Mods flags
@@ -338,22 +354,6 @@ export class InputHandler {
     // For now, we don't set CAPSLOCK or NUMLOCK flags
 
     return mods;
-  }
-
-  /**
-   * Check if this is a printable character with no special modifiers
-   * @param event - KeyboardEvent
-   * @returns true if printable character
-   */
-  private isPrintableCharacter(event: KeyboardEvent): boolean {
-    // If Ctrl, Alt, or Meta (Cmd on Mac) is pressed, it's not a simple printable character
-    // Exception: AltGr (Ctrl+Alt on some keyboards) can produce printable characters
-    if (event.ctrlKey && !event.altKey) return false;
-    if (event.altKey && !event.ctrlKey) return false;
-    if (event.metaKey) return false; // Cmd key on Mac
-
-    // If key produces a single printable character
-    return event.key.length === 1;
   }
 
   /**
@@ -402,156 +402,73 @@ export class InputHandler {
       return;
     }
 
-    // For printable characters without modifiers, send the character directly
-    // This handles: a-z, A-Z (with shift), 0-9, punctuation, etc.
-    if (this.isPrintableCharacter(event)) {
-      event.preventDefault();
-      this.onDataCallback(event.key);
-      this.recordKeyDownData(event.key);
-      return;
-    }
-
-    // Map the physical key code
+    // Map the physical key code. Events with no corresponding Ghostty Key
+    // (media keys, etc.) are dropped silently.
     const key = this.mapKeyCode(event.code);
-    if (key === null) {
-      // Unknown key - ignore it
-      return;
-    }
+    if (key === null) return;
 
-    // Extract modifiers
     const mods = this.extractModifiers(event);
 
-    // Handle simple special keys that produce standard sequences
-    if (mods === Mods.NONE || mods === Mods.SHIFT) {
-      let simpleOutput: string | null = null;
-
-      switch (key) {
-        case Key.ENTER:
-          simpleOutput = '\r'; // Carriage return
-          break;
-        case Key.TAB:
-          if (mods === Mods.SHIFT) {
-            simpleOutput = '\x1b[Z'; // Backtab
-          } else {
-            simpleOutput = '\t'; // Tab
-          }
-          break;
-        case Key.BACKSPACE:
-          simpleOutput = '\x7F'; // DEL (most terminals use 0x7F for backspace)
-          break;
-        case Key.ESCAPE:
-          simpleOutput = '\x1B'; // ESC
-          break;
-        // Arrow keys are handled by the encoder (respects application cursor mode)
-        // Navigation keys
-        case Key.HOME:
-          simpleOutput = '\x1B[H';
-          break;
-        case Key.END:
-          simpleOutput = '\x1B[F';
-          break;
-        case Key.INSERT:
-          simpleOutput = '\x1B[2~';
-          break;
-        case Key.DELETE:
-          simpleOutput = '\x1B[3~';
-          break;
-        case Key.PAGE_UP:
-          simpleOutput = '\x1B[5~';
-          break;
-        case Key.PAGE_DOWN:
-          simpleOutput = '\x1B[6~';
-          break;
-        // Function keys
-        case Key.F1:
-          simpleOutput = '\x1BOP';
-          break;
-        case Key.F2:
-          simpleOutput = '\x1BOQ';
-          break;
-        case Key.F3:
-          simpleOutput = '\x1BOR';
-          break;
-        case Key.F4:
-          simpleOutput = '\x1BOS';
-          break;
-        case Key.F5:
-          simpleOutput = '\x1B[15~';
-          break;
-        case Key.F6:
-          simpleOutput = '\x1B[17~';
-          break;
-        case Key.F7:
-          simpleOutput = '\x1B[18~';
-          break;
-        case Key.F8:
-          simpleOutput = '\x1B[19~';
-          break;
-        case Key.F9:
-          simpleOutput = '\x1B[20~';
-          break;
-        case Key.F10:
-          simpleOutput = '\x1B[21~';
-          break;
-        case Key.F11:
-          simpleOutput = '\x1B[23~';
-          break;
-        case Key.F12:
-          simpleOutput = '\x1B[24~';
-          break;
-      }
-
-      if (simpleOutput !== null) {
-        event.preventDefault();
-        this.onDataCallback(simpleOutput);
-        this.recordKeyDownData(simpleOutput);
-        return;
-      }
+    // Pass event.key as utf8 when it is a single Unicode scalar (a printable
+    // character, including non-ASCII and surrogate-pair emoji). Named keys
+    // like "Enter", "ArrowUp", "F1", "Dead" are longer strings and produce
+    // undefined here, so the encoder relies on the logical key alone.
+    //
+    // Case is preserved intentionally: the encoder uses the utf8 byte to
+    // pick the C0 sequence for Ctrl+letter, and needs the actual shifted
+    // character for the text-output path.
+    let utf8: string | undefined;
+    if (event.key.length > 0 && event.key !== 'Dead' && event.key !== 'Unidentified') {
+      const cp = event.key.codePointAt(0);
+      const scalarLen = cp !== undefined && cp > 0xffff ? 2 : 1;
+      if (event.key.length === scalarLen) utf8 = event.key;
     }
 
-    // Determine action (we only care about PRESS for now, not RELEASE or REPEAT)
-    const action = KeyAction.PRESS;
+    // Sync encoder options with terminal mode state before every encode.
+    // DEC mode 1 (DECCKM) → cursor-key application mode.
+    // DEC mode 66 (DECNKM) → keypad application mode.
+    // syncEncoderOption skips the WASM round-trip when the value hasn't
+    // changed since last keystroke, which is the common case.
+    if (this.getModeCallback) {
+      this.syncEncoderOption(KeyEncoderOption.CURSOR_KEY_APPLICATION, this.getModeCallback(1));
+      this.syncEncoderOption(KeyEncoderOption.KEYPAD_KEY_APPLICATION, this.getModeCallback(66));
+    }
 
-    // For non-printable keys or keys with modifiers, encode using Ghostty
+    // mapKeyCode succeeded → we own this key. Prevent browser default
+    // (search shortcuts, F11 fullscreen, Ctrl+W close tab, etc.) before
+    // attempting to encode, so a failed or empty encode drops the
+    // keystroke silently rather than letting it trigger a browser action.
+    //
+    // This is a deliberate divergence from native Ghostty, which returns
+    // `.ignored` from keyCallback when the encoder produces no output and
+    // lets the apprt decide whether to propagate the key (Surface.zig
+    // around line 2670). In a native context that lets OS-level shortcuts
+    // and apprt keybinds run; in a browser context "ignored" would mean
+    // the browser fires its own default action with no intermediate layer
+    // to filter, which is rarely what users typing into a terminal want.
+    // Empty-encode mapped keys are also rare in our path: mapKeyCode
+    // already filters unmapped keys, and most mapped keys produce non-
+    // empty encodings in default mode.
+    event.preventDefault();
+    event.stopPropagation();
+
+    let data: string;
     try {
-      // Sync encoder options with terminal mode state
-      // Mode 1 (DECCKM) controls whether arrow keys send CSI or SS3 sequences
-      if (this.getModeCallback) {
-        const appCursorMode = this.getModeCallback(1);
-        this.encoder.setOption(KeyEncoderOption.CURSOR_KEY_APPLICATION, appCursorMode);
-      }
-
-      // For letter/number keys, even with modifiers, pass the base character
-      // This helps the encoder produce correct control sequences (e.g., Ctrl+A = 0x01)
-      // For special keys (Enter, Arrow keys, etc.), don't pass utf8
-      const utf8 =
-        event.key.length === 1 && event.key.charCodeAt(0) < 128
-          ? event.key.toLowerCase() // Use lowercase for consistency
-          : undefined;
-
       const encoded = this.encoder.encode({
-        action,
+        action: KeyAction.PRESS,
         key,
         mods,
         utf8,
       });
-
-      // Convert Uint8Array to string
-      const decoder = new TextDecoder();
-      const data = decoder.decode(encoded);
-
-      // Prevent default browser behavior
-      event.preventDefault();
-      event.stopPropagation();
-
-      // Emit the data
-      if (data.length > 0) {
-        this.onDataCallback(data);
-        this.recordKeyDownData(data);
-      }
+      data = encoded.length === 0 ? '' : new TextDecoder().decode(encoded);
     } catch (error) {
-      // Encoding failed - log but don't crash
       console.warn('Failed to encode key:', event.code, error);
+      return;
+    }
+
+    if (data.length > 0) {
+      this.onDataCallback(data);
+      this.recordKeyDownData(data);
     }
   }
 

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -212,6 +212,10 @@ export class InputHandler {
   // changed. `undefined` means "never synced"; any first query on a new
   // handler will emit one setOption per option regardless of mode state.
   private syncedEncoderOptions = new Map<KeyEncoderOption, boolean | number>();
+  // Reused across keystrokes to avoid the TextDecoder allocation per call.
+  // Once #8 merges and we migrate to encoder.encodeToString, this field
+  // goes away.
+  private decoder = new TextDecoder();
 
   /**
    * Create a new InputHandler
@@ -460,7 +464,7 @@ export class InputHandler {
         mods,
         utf8,
       });
-      data = encoded.length === 0 ? '' : new TextDecoder().decode(encoded);
+      data = encoded.length === 0 ? '' : this.decoder.decode(encoded);
     } catch (error) {
       console.warn('Failed to encode key:', event.code, error);
       return;


### PR DESCRIPTION
## Summary

Deletes the \"printable character\" and \"simple special keys\" fast paths from \`handleKeyDown\` and routes everything through the Ghostty encoder. The fast paths were microsecond-scale optimizations (negligible at human typing rates) that silently diverged from the encoder's behavior as Ghostty grew features around them. Every keyboard bug we have patched in this file over the past few months came from that divergence.

This was originally split from #4 alongside #8 (KeyEncoder reuse + \`encodeToString\`). After review, I've un-stacked the two: **this PR does not depend on #8 and can merge in either order.** We call \`encoder.encode\` (the API already on main) and decode its bytes with a \`TextDecoder\` at the call site. If #8 merges first, a follow-up can migrate this one call site to \`encoder.encodeToString\` to skip the per-keystroke \`TextDecoder\` construction.

## Bugs fixed

- **Shift+Enter** was indistinguishable from Enter (previously hot-patched in \`6e28bc5\`; now subsumed — Shift+Enter emits \`\x1b[27;2;13~\` in default mode, \`\x1b[13;2u\` under Kitty).
- **Shift+Home** / **Shift+End** / **Shift+PageUp** / **Shift+PageDown** / **Shift+F1..F12** silently dropped the Shift modifier because the hardcoded switch emitted the unmodified xterm sequence. Shift+Home now correctly emits \`\x1b[1;2H\`, Shift+F1 emits \`\x1b[1;2P\`.
- **Home / End ignored DECCKM** even though Arrow keys already routed through the encoder to honor it. Home now emits \`\x1b[H\` in normal cursor mode and \`\x1bOH\` in application cursor mode.
- **Kitty keyboard protocol flags** were ignored for any key that hit a fast path (i.e. most keys). With the bypass removed, flags set on the encoder affect every key.
- **Non-BMP characters** (surrogate-pair emoji 😀) were dropped entirely. A non-ASCII BMP character (e.g. 你) with modifiers lost its utf8 because the encoder-fallback gated utf8 on \`charCodeAt(0) < 128\`.
- **Case preservation**: the encoder-fallback called \`event.key.toLowerCase()\`, which stripped case information the encoder needs to distinguish shifted letters. Shift+2 now correctly emits \`@\` rather than \`2\`.

Regression tests have been trimmed to two representative cases — \`Shift+Enter\` (modifiers reach encoder) and surrogate-pair emoji (utf8 passthrough) — since the original 11 mostly exercised the same code path.

## Hot-path optimization

\`InputHandler.syncEncoderOption\` caches the last value pushed per encoder option and short-circuits when unchanged. Terminal modes rarely change between keystrokes (DECCKM, DECNKM are set once by the app and stay for the session), so in steady state this skips both \`ghostty_key_encoder_setopt\` WASM round-trips per keystroke.

Note that \`getModeCallback\` itself still runs every keystroke and queries \`ghostty_terminal_get_mode\` under the hood — that's also a WASM call (I had the description wrong originally, thanks to the reviewer for catching it). There's no change-notification channel from the terminal, so we either query per keystroke or introduce a cache-invalidation hook, and two WASM queries per keystroke is comfortably below any noticeable threshold at human typing rates. A JS-side cache wired to terminal-mode-change events could shave the remaining pair, but that's a larger shape change best explored separately.

## Browser-default ownership

If \`mapKeyCode\` succeeds (the terminal owns the key), \`preventDefault\` + \`stopPropagation\` fire before the encoding attempt. A failed or empty encode now drops the keystroke silently instead of letting browser defaults fire (F11 fullscreen, Ctrl+W close tab, Ctrl+F find, etc.). This is documented as a deliberate divergence from native Ghostty's \`keyCallback\` policy, which returns \`.ignored\` on empty encode and lets the apprt propagate.

## What's *not* in this PR

The currently-built WASM exports \`set_composing\` but not \`set_unshifted_codepoint\` or \`set_consumed_mods\`. Upstream \`ghostty/src/terminal/c/main.zig\` already exports all three, so these become trivial follow-ups once the WASM is rebuilt:

1. Add \`ghostty_key_event_set_unshifted_codepoint\` / \`set_consumed_mods\` to the WASM exports interface.
2. In \`handleKeyDown\`, derive \`unshiftedCodepoint\` from \`event.code\` so Kitty and CSI-u paths correctly preserve Shift for letters.

Related follow-ups tracked: #5 (\`keybindOverrides\` for legacy-compat), #6 (project-wide OOM-handling audit), #7 (macOS Option-as-Alt).

## Relationship to #8

Previously this PR was stacked on #8. After review, I un-stacked them — this PR uses \`encoder.encode\` + inline \`TextDecoder\` instead of #8's new \`encoder.encodeToString\`. The 4 extra lines at the call site are worth having both PRs be independently mergeable. A micro follow-up after both land can switch this site to \`encoder.encodeToString\` and reclaim the per-keystroke \`TextDecoder\` allocation.

## Test plan

- [x] \`bun test\` — 345/345 passing (342 pre-existing + 2 regression tests + 1 DECCKM mode-change test).
- [x] \`tsc --noEmit\` — clean.
- [x] \`biome check lib/\` — clean.
- [x] \`prettier --check\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)