### PR TITLE
refactor(encoder): add encodeToString and migrate InputHandler

### DIFF
--- a/lib/ghostty.ts
+++ b/lib/ghostty.ts
@@ -155,9 +155,10 @@ export class Ghostty {
   }
 }
 
-// Singleton TextEncoder shared across all KeyEncoder instances. Constructing
-// one per keystroke showed up as avoidable allocation pressure.
+// Singleton text codecs shared across all KeyEncoder instances. Constructing
+// these per keystroke showed up as avoidable allocation pressure.
 const TEXT_ENCODER = new TextEncoder();
+const TEXT_DECODER = new TextDecoder();
 
 /**
  * Key Encoder - converts keyboard events into terminal escape sequences
@@ -250,7 +251,36 @@ export class KeyEncoder {
     this.setOption(KeyEncoderOption.KITTY_KEYBOARD_FLAGS, flags);
   }
 
+  /**
+   * Encode a key event and return a stable, caller-owned Uint8Array.
+   * Safe to hold across further encode() calls.
+   */
   encode(event: KeyEvent): Uint8Array {
+    // .slice() copies out of WASM memory so the returned array survives
+    // future WASM memory growth or reuse of this.outBufPtr.
+    return this.encodeToView(event).slice();
+  }
+
+  /**
+   * Encode a key event and return the UTF-8 string, or null if the
+   * encoder produced no output.
+   *
+   * Avoids the copy that encode() makes: TextDecoder.decode synchronously
+   * reads from the view and produces an independent string, so the view
+   * into WASM memory doesn't need to outlive this call.
+   */
+  encodeToString(event: KeyEvent): string | null {
+    const view = this.encodeToView(event);
+    if (view.length === 0) return null;
+    return TEXT_DECODER.decode(view);
+  }
+
+  /**
+   * Encode and return a view into the WASM output buffer. The view is
+   * only valid until the next encode() call (or until WASM memory grows).
+   * Callers that need a stable array must copy via .slice().
+   */
+  private encodeToView(event: KeyEvent): Uint8Array {
     const eventPtr = this.eventPtr;
 
     // Set every field on every call so stale state from a previous encode
@@ -325,9 +355,7 @@ export class KeyEncoder {
     }
 
     const bytesWritten = new DataView(this.exports.memory.buffer).getUint32(this.writtenPtr, true);
-    // .slice() copies out of WASM memory so the returned array survives
-    // future WASM memory growth or reuse of this.outBufPtr.
-    return new Uint8Array(this.exports.memory.buffer, this.outBufPtr, bytesWritten).slice();
+    return new Uint8Array(this.exports.memory.buffer, this.outBufPtr, bytesWritten);
   }
 
   dispose(): void {

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -212,10 +212,6 @@ export class InputHandler {
   // changed. `undefined` means "never synced"; any first query on a new
   // handler will emit one setOption per option regardless of mode state.
   private syncedEncoderOptions = new Map<KeyEncoderOption, boolean | number>();
-  // Reused across keystrokes to avoid the TextDecoder allocation per call.
-  // Once #8 merges and we migrate to encoder.encodeToString, this field
-  // goes away.
-  private decoder = new TextDecoder();
 
   /**
    * Create a new InputHandler
@@ -456,21 +452,20 @@ export class InputHandler {
     event.preventDefault();
     event.stopPropagation();
 
-    let data: string;
+    let data: string | null;
     try {
-      const encoded = this.encoder.encode({
+      data = this.encoder.encodeToString({
         action: KeyAction.PRESS,
         key,
         mods,
         utf8,
       });
-      data = encoded.length === 0 ? '' : this.decoder.decode(encoded);
     } catch (error) {
       console.warn('Failed to encode key:', event.code, error);
       return;
     }
 
-    if (data.length > 0) {
+    if (data !== null && data.length > 0) {
       this.onDataCallback(data);
       this.recordKeyDownData(data);
     }

--- a/lib/key-encoder.test.ts
+++ b/lib/key-encoder.test.ts
@@ -46,6 +46,35 @@ describe('KeyEncoder', () => {
     }
   });
 
+  test('encodeToString() returns the UTF-8 string for a typical keystroke', () => {
+    const encoder = ghostty.createKeyEncoder();
+    try {
+      const out = encoder.encodeToString({
+        action: KeyAction.PRESS,
+        key: Key.ENTER,
+        mods: Mods.NONE,
+      });
+      expect(out).toBe('\r');
+    } finally {
+      encoder.dispose();
+    }
+  });
+
+  test('encodeToString() returns null when the encoder produces no output', () => {
+    const encoder = ghostty.createKeyEncoder();
+    try {
+      // A modifier key alone (Shift) produces no output in legacy mode.
+      const out = encoder.encodeToString({
+        action: KeyAction.PRESS,
+        key: Key.SHIFT_LEFT,
+        mods: Mods.NONE,
+      });
+      expect(out).toBeNull();
+    } finally {
+      encoder.dispose();
+    }
+  });
+
   test('setKittyFlags affects encoded output', () => {
     const encoder = ghostty.createKeyEncoder();
     const decoder = new TextDecoder();


### PR DESCRIPTION
## Summary

Depends on #8.

Adds \`encodeToString(event): string | null\` alongside \`encode()\` on \`KeyEncoder\` and migrates \`InputHandler.handleKeyDown\` to use it. \`encodeToString\` skips the per-keystroke copy that \`encode()\` makes: \`TextDecoder.decode\` reads the WASM output view directly and produces an independent string, so the view doesn't need to outlive the call.

## Why split from #8

#8 originally included this new method plus a \`set_composing\` plumbing path, written in anticipation of callers in a follow-up PR. When the follow-up (the previously-merged input-handler refactor) un-stacked and didn't end up using either, both sat as dead code on #8. This PR is the \"actually add the method, and actually use it\" follow-up — one consumer call site migrated in the same patch so the API isn't shipped speculatively.

\`set_composing\` is not re-added — it had no concrete caller or plan.

## Changes

- **\`KeyEncoder\`**: split \`encode()\` into \`encode()\` + \`encodeToView()\` (private) + \`encodeToString()\`. \`encode()\` keeps its existing contract (stable \`Uint8Array\` via \`.slice()\`). \`encodeToString()\` decodes the view directly via a module-level \`TEXT_DECODER\` singleton.
- **\`InputHandler.handleKeyDown\`**: drops the per-instance \`decoder\` field and the inline \`new TextDecoder().decode(...)\` call, replacing the encode/decode pair with \`encoder.encodeToString(...)\`.
- **Tests**: two new cases in \`lib/key-encoder.test.ts\` — typical keystroke string output, and null return on empty encoder output (modifier key alone).

## Test plan

- [x] \`bun test\` — 353/353 passing.
- [x] \`tsc --noEmit\` — clean.
- [x] \`biome check lib/\` — clean.
- [x] \`prettier --check\` — clean.