### PR TITLE
fix(input): mouse up outside canvas and window blur leave no stuck buttons

### DIFF
--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -1268,6 +1268,132 @@ describe('InputHandler', () => {
     });
   });
 
+  describe('Mouse event cleanup', () => {
+    // Mouse tracking config that always reports tracking enabled, with 10x20
+    // cells and a 0,0 canvas offset so pixel→cell math is easy to reason about.
+    const trackingMouseConfig = {
+      hasMouseTracking: () => true,
+      hasSgrMouseMode: () => true,
+      getCellDimensions: () => ({ width: 10, height: 20 }),
+      getCanvasOffset: () => ({ left: 0, top: 0 }),
+    };
+
+    test('mouseup on document (not container) clears pressed-button state', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        trackingMouseConfig
+      );
+
+      // Press inside the container.
+      container.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 5, clientY: 10 }));
+      expect(dataReceived.length).toBe(1);
+
+      // Release on document, outside the container. The listener is attached
+      // to document for exactly this case; the old code attached to container
+      // and would miss this release, leaving the button flagged as held.
+      document.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 5, clientY: 10 }));
+      expect(dataReceived.length).toBe(2);
+      expect(dataReceived[1]).toMatch(/^\x1b\[<0;\d+;\d+m$/); // SGR release
+
+      // A subsequent motion in any-motion mode must not report a drag —
+      // the button bit should have been cleared.
+      // Install a getMode callback that enables any-motion tracking (1003).
+      (handler as any).getModeCallback = (mode: number) => mode === 1003;
+      container.dispatchEvent(new MouseEvent('mousemove', { button: 0, clientX: 15, clientY: 10 }));
+      // Motion-with-no-button reports button 35 (motion flag 32 + base 3 for
+      // "no button held"); see xterm SGR encoding in handleMouseMove.
+      const last = dataReceived[dataReceived.length - 1];
+      expect(last).toMatch(/^\x1b\[<35;/);
+    });
+
+    test('mouseup outside canvas bounds still clears button state', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          ...trackingMouseConfig,
+          // Zero cell dims → pixelToCell returns null, so the old code would
+          // early-return before clearing the button bit.
+          getCellDimensions: () => ({ width: 0, height: 0 }),
+        }
+      );
+
+      // Force the pressed-button bit by invoking the private handler directly
+      // (mousedown would also early-return on zero dims).
+      (handler as any).mouseButtonsPressed = 0b001;
+
+      document.dispatchEvent(new MouseEvent('mouseup', { button: 0 }));
+      expect((handler as any).mouseButtonsPressed).toBe(0);
+    });
+
+    test('window blur clears all pressed-button state', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        trackingMouseConfig
+      );
+
+      (handler as any).mouseButtonsPressed = 0b101; // left + right held
+
+      window.dispatchEvent(new Event('blur'));
+      expect((handler as any).mouseButtonsPressed).toBe(0);
+    });
+
+    test('dispose removes the document mouseup and window blur listeners', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        trackingMouseConfig
+      );
+
+      handler.dispose();
+
+      // After dispose, both listeners should be detached. Dispatching must
+      // not touch the disposed handler's state.
+      (handler as any).mouseButtonsPressed = 0b010;
+      document.dispatchEvent(new MouseEvent('mouseup', { button: 1 }));
+      window.dispatchEvent(new Event('blur'));
+      expect((handler as any).mouseButtonsPressed).toBe(0b010);
+    });
+  });
+
   describe('Motion encoding (SGR)', () => {
     // Mouse tracking config enabling any-motion tracking (mode 1003).
     const trackingMouseConfig = {

--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -1345,6 +1345,31 @@ describe('InputHandler', () => {
       expect((handler as any).mouseButtonsPressed).toBe(0);
     });
 
+    test('mouseup without a prior press on this instance sends no release', () => {
+      // Simulates a second terminal on the same page: the mousedown happened
+      // in another InputHandler (or outside any terminal), so this instance
+      // never set a bit in mouseButtonsPressed. The document-level mouseup
+      // must not forward a spurious release to this PTY.
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        trackingMouseConfig
+      );
+
+      expect((handler as any).mouseButtonsPressed).toBe(0);
+      document.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 5, clientY: 10 }));
+      expect(dataReceived.length).toBe(0);
+    });
+
     test('window blur clears all pressed-button state', () => {
       const handler = new InputHandler(
         ghostty,

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -194,6 +194,7 @@ export class InputHandler {
   private mouseupListener: ((e: MouseEvent) => void) | null = null;
   private mousemoveListener: ((e: MouseEvent) => void) | null = null;
   private wheelListener: ((e: WheelEvent) => void) | null = null;
+  private blurListener: (() => void) | null = null;
   private isComposing = false;
   private isDisposed = false;
   private mouseButtonsPressed = 0; // Track which buttons are pressed for motion reporting
@@ -311,14 +312,25 @@ export class InputHandler {
     this.mousedownListener = this.handleMouseDown.bind(this);
     this.container.addEventListener('mousedown', this.mousedownListener);
 
+    // mouseup is on `document` (not container) so that releases outside the
+    // terminal canvas still clear button state. Without this, a TUI app sees a
+    // press without a matching release if the cursor leaves before the user
+    // lets go, causing stuck-mouse behavior. Matches how SelectionManager and
+    // the Terminal scrollbar already listen.
     this.mouseupListener = this.handleMouseUp.bind(this);
-    this.container.addEventListener('mouseup', this.mouseupListener);
+    document.addEventListener('mouseup', this.mouseupListener);
 
     this.mousemoveListener = this.handleMouseMove.bind(this);
     this.container.addEventListener('mousemove', this.mousemoveListener);
 
     this.wheelListener = this.handleWheel.bind(this);
     this.container.addEventListener('wheel', this.wheelListener, { passive: false });
+
+    // If the window loses focus (e.g. Alt-Tab) while a button is held, the
+    // mouseup event never fires. Reset pressed-button state on blur so TUI
+    // apps don't see a permanently held button after focus returns.
+    this.blurListener = this.handleWindowBlur.bind(this);
+    window.addEventListener('blur', this.blurListener);
   }
 
   /**
@@ -762,20 +774,36 @@ export class InputHandler {
 
   /**
    * Handle mouseup event
+   *
+   * Listens on `document`, so this fires even when the release happens
+   * outside the terminal canvas. We clear the pressed-button bit before the
+   * pixelToCell null-check so button state is always cleaned up — otherwise
+   * a release outside the canvas would leave the button flagged as held and
+   * subsequent motion events would report a drag.
    */
   private handleMouseUp(event: MouseEvent): void {
     if (this.isDisposed) return;
     if (!this.mouseConfig?.hasMouseTracking()) return;
 
+    const button = event.button;
+
+    // Clear pressed button first, before any early return, so we never leave
+    // a bit set when the release happens outside canvas bounds.
+    this.mouseButtonsPressed &= ~(1 << button);
+
     const cell = this.pixelToCell(event);
     if (!cell) return;
 
-    const button = event.button;
-
-    // Clear pressed button
-    this.mouseButtonsPressed &= ~(1 << button);
-
     this.sendMouseEvent(button, cell.col, cell.row, true, event);
+  }
+
+  /**
+   * Handle window blur — clear all pressed-button state so a held button
+   * doesn't stay flagged as pressed after Alt-Tab or focus loss.
+   */
+  private handleWindowBlur(): void {
+    if (this.isDisposed) return;
+    this.mouseButtonsPressed = 0;
   }
 
   /**
@@ -1021,7 +1049,7 @@ export class InputHandler {
     }
 
     if (this.mouseupListener) {
-      this.container.removeEventListener('mouseup', this.mouseupListener);
+      document.removeEventListener('mouseup', this.mouseupListener);
       this.mouseupListener = null;
     }
 
@@ -1033,6 +1061,11 @@ export class InputHandler {
     if (this.wheelListener) {
       this.container.removeEventListener('wheel', this.wheelListener);
       this.wheelListener = null;
+    }
+
+    if (this.blurListener) {
+      window.removeEventListener('blur', this.blurListener);
+      this.blurListener = null;
     }
 
     this.isDisposed = true;

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -776,20 +776,33 @@ export class InputHandler {
    * Handle mouseup event
    *
    * Listens on `document`, so this fires even when the release happens
-   * outside the terminal canvas. We clear the pressed-button bit before the
-   * pixelToCell null-check so button state is always cleaned up — otherwise
-   * a release outside the canvas would leave the button flagged as held and
-   * subsequent motion events would report a drag.
+   * outside the terminal canvas. Two behaviors flow from that:
+   *
+   *   - Always clear the pressed-button bit before any early return, so
+   *     a release outside the canvas still cleans up local state and
+   *     subsequent motion doesn't look like a drag.
+   *   - Only forward the release to the PTY if this instance previously
+   *     saw the matching press. Otherwise, in a page with multiple
+   *     terminals, every instance would send a spurious release for every
+   *     mouseup anywhere on the document.
    */
   private handleMouseUp(event: MouseEvent): void {
     if (this.isDisposed) return;
-    if (!this.mouseConfig?.hasMouseTracking()) return;
 
     const button = event.button;
+    const wasPressed = (this.mouseButtonsPressed & (1 << button)) !== 0;
 
     // Clear pressed button first, before any early return, so we never leave
-    // a bit set when the release happens outside canvas bounds.
+    // a bit set when the release happens outside canvas bounds or if the
+    // tracking mode changed between press and release.
     this.mouseButtonsPressed &= ~(1 << button);
+
+    if (!this.mouseConfig?.hasMouseTracking()) return;
+
+    // Only report the release if this instance saw the press. Without this,
+    // releases originating in another terminal or outside any terminal
+    // would all fire here once the document-level listener is attached.
+    if (!wasPressed) return;
 
     const cell = this.pixelToCell(event);
     if (!cell) return;


### PR DESCRIPTION
## Summary

InputHandler attached its `mouseup` listener to `this.container`, so a release
that happened after the cursor left the canvas was lost. TUI apps saw a press
without a matching release and reported a permanently held button — any
subsequent motion looked like a drag.

Three fixes:

1. Move the `mouseup` listener from `container` to `document`, matching
   SelectionManager and the scrollbar. Releases anywhere on the page now
   reach the handler.
2. Clear `mouseButtonsPressed` before the `pixelToCell` null-check so button
   state is cleaned up even when the release is outside canvas bounds (zero
   cell dims, cursor over page chrome, etc.).
3. Register a `window.blur` listener that zeroes `mouseButtonsPressed`. If
   focus leaves the window while a button is held (Alt-Tab), the browser
   never fires `mouseup`, so without this the button would remain flagged
   on focus return.

Dispose cleans up both the document-mouseup and window-blur listeners.

## Background

This was previously patched directly into the compiled dist bundle in
quite-app (anthropics/quite-app#83) because the fix never landed upstream.
The recent revendor (anthropics/quite-app#591) rebuilt the bundle from
upstream and clobbered the patch, regressing stuck-button behavior. Landing
here so the fix survives future revendors.

## Test plan

- [x] `bun test lib/input-handler.test.ts` — 59/59 pass (4 new tests added)
- [x] `bun test` — 351/351 pass
- [x] `bun run typecheck` — clean
- [x] `biome check lib/input-handler.ts lib/input-handler.test.ts` — clean
- [x] `prettier --check lib/input-handler.ts lib/input-handler.test.ts` — clean