### PR TITLE
feat(url-regex): detect URLs that soft-wrap across rows

### DIFF
--- a/lib/providers/url-regex-provider.ts
+++ b/lib/providers/url-regex-provider.ts
@@ -13,8 +13,9 @@ import type { IBufferRange, ILink, ILinkProvider } from '../types';
 /**
  * URL Regex Provider
  *
- * Detects plain text URLs on a single line using regex.
- * Does not support multi-line URLs or file paths.
+ * Detects plain text URLs using regex. Handles URLs that have been
+ * soft-wrapped across multiple buffer rows by joining the rows in the
+ * wrap chain that contains the queried row before applying the regex.
  *
  * Supported protocols:
  * - https://, http://
@@ -22,6 +23,12 @@ import type { IBufferRange, ILink, ILinkProvider } from '../types';
  * - ftp://, ssh://, git://
  * - tel:, magnet:
  * - gemini://, gopher://, news:
+ *
+ * Wrap-chain semantics: a buffer line's `isWrapped` flag is `true` when
+ * the line is the *continuation* of a soft-wrap from the previous line.
+ * To find the chain that contains row `y` we walk backwards from `y`
+ * while the current row's `isWrapped` is true, then forwards from there
+ * while the next row's `isWrapped` is true.
  */
 export class UrlRegexProvider implements ILinkProvider {
   /**
@@ -38,66 +45,117 @@ export class UrlRegexProvider implements ILinkProvider {
    */
   private static readonly TRAILING_PUNCTUATION = /[.,;!?)\]]+$/;
 
+  /**
+   * Maximum number of soft-wrapped rows to traverse in either direction
+   * when assembling a wrap chain. Bounds worst-case work on pathological
+   * input (e.g. a screenful of unbroken characters); any real URL fits
+   * easily.
+   */
+  private static readonly MAX_WRAP_CHAIN_ROWS = 256;
+
   constructor(private terminal: ITerminalForUrlProvider) {}
 
   /**
-   * Provide all regex-detected URLs on the given row
+   * Provide all regex-detected URLs whose range intersects the given row.
+   *
+   * For wrapped URLs the same link is returned no matter which row in the
+   * chain the caller queries. The link's `range` may span multiple rows;
+   * `LinkManager.isPositionInLink` correctly handles such ranges.
    */
   provideLinks(y: number, callback: (links: ILink[] | undefined) => void): void {
-    const links: ILink[] = [];
+    const buffer = this.terminal.buffer.active;
 
-    const line = this.terminal.buffer.active.getLine(y);
-    if (!line) {
+    if (!buffer.getLine(y)) {
       callback(undefined);
       return;
     }
 
-    // Convert line cells to text
-    const lineText = this.lineToText(line);
+    // Walk back to the start of the wrap chain containing row y. The
+    // current row is a continuation iff its own `isWrapped` is true.
+    let startRow = y;
+    let walked = 0;
+    while (startRow > 0 && walked < UrlRegexProvider.MAX_WRAP_CHAIN_ROWS) {
+      const cur = buffer.getLine(startRow);
+      if (!cur || !cur.isWrapped) break;
+      startRow--;
+      walked++;
+    }
 
-    // Reset regex state (global flag maintains state)
+    // Walk forward to the end of the chain by extending while the *next*
+    // row is a continuation.
+    let endRow = startRow;
+    while (
+      endRow - startRow < UrlRegexProvider.MAX_WRAP_CHAIN_ROWS &&
+      endRow < buffer.length - 1
+    ) {
+      const next = buffer.getLine(endRow + 1);
+      if (!next || !next.isWrapped) break;
+      endRow++;
+    }
+
+    // Build the joined string and a per-row offset table so regex match
+    // indices can be mapped back to (col, row).
+    let joined = '';
+    const rowStartIdx: number[] = [];
+    for (let r = startRow; r <= endRow; r++) {
+      rowStartIdx.push(joined.length);
+      const line = buffer.getLine(r);
+      if (!line) continue;
+      joined += this.lineToText(line);
+    }
+
+    const links: ILink[] = [];
+
+    // Reset regex state (global flag maintains state across calls)
     UrlRegexProvider.URL_REGEX.lastIndex = 0;
 
-    // Find all URL matches in the line
-    let match: RegExpExecArray | null = UrlRegexProvider.URL_REGEX.exec(lineText);
+    let match: RegExpExecArray | null = UrlRegexProvider.URL_REGEX.exec(joined);
     while (match !== null) {
       let url = match[0];
-      const startX = match.index;
-      let endX = match.index + url.length - 1; // Inclusive end
+      const startIdx = match.index;
+      let endIdx = startIdx + url.length - 1; // Inclusive end
 
       // Strip trailing punctuation
       const stripped = url.replace(UrlRegexProvider.TRAILING_PUNCTUATION, '');
       if (stripped.length < url.length) {
         url = stripped;
-        endX = startX + url.length - 1;
+        endIdx = startIdx + url.length - 1;
       }
 
       // Skip if URL is too short (e.g., just "http://")
       if (url.length > 8) {
-        links.push({
-          text: url,
-          range: {
-            start: { x: startX, y },
-            end: { x: endX, y },
-          },
-          activate: (event) => {
-            // Open link if Ctrl/Cmd is pressed
-            if (event.ctrlKey || event.metaKey) {
-              window.open(url, '_blank', 'noopener,noreferrer');
-            }
-          },
-        });
+        const startPos = this.joinedIdxToRowCol(startIdx, rowStartIdx, startRow);
+        const endPos = this.joinedIdxToRowCol(endIdx, rowStartIdx, startRow);
+
+        // Only surface links whose range intersects the queried row. The
+        // LinkManager seeds its cache per scanned row; emitting links that
+        // don't touch `y` would pollute the cache.
+        if (startPos.y <= y && endPos.y >= y) {
+          const range: IBufferRange = { start: startPos, end: endPos };
+          const href = url;
+          links.push({
+            text: href,
+            range,
+            activate: (event) => {
+              // Open link if Ctrl/Cmd is pressed
+              if (event.ctrlKey || event.metaKey) {
+                window.open(href, '_blank', 'noopener,noreferrer');
+              }
+            },
+          });
+        }
       }
 
       // Get next match
-      match = UrlRegexProvider.URL_REGEX.exec(lineText);
+      match = UrlRegexProvider.URL_REGEX.exec(joined);
     }
 
     callback(links.length > 0 ? links : undefined);
   }
 
   /**
-   * Convert a buffer line to plain text string
+   * Convert a buffer line to plain text string. Control characters and
+   * empty cells become spaces so column indices map 1:1 onto the string.
    */
   private lineToText(line: IBufferLineForUrlProvider): string {
     const chars: string[] = [];
@@ -121,6 +179,22 @@ export class UrlRegexProvider implements ILinkProvider {
     return chars.join('');
   }
 
+  /**
+   * Map an index in the joined string back to a (col, row) buffer position.
+   */
+  private joinedIdxToRowCol(
+    joinedIdx: number,
+    rowStartIdx: number[],
+    baseRow: number,
+  ): { x: number; y: number } {
+    for (let i = rowStartIdx.length - 1; i >= 0; i--) {
+      if (joinedIdx >= rowStartIdx[i]) {
+        return { x: joinedIdx - rowStartIdx[i], y: baseRow + i };
+      }
+    }
+    return { x: 0, y: baseRow };
+  }
+
   dispose(): void {
     // No resources to clean up
   }
@@ -132,6 +206,8 @@ export class UrlRegexProvider implements ILinkProvider {
 export interface ITerminalForUrlProvider {
   buffer: {
     active: {
+      /** Total number of rows accessible via `getLine` (viewport + scrollback). */
+      length: number;
       getLine(y: number): IBufferLineForUrlProvider | undefined;
     };
   };
@@ -142,6 +218,12 @@ export interface ITerminalForUrlProvider {
  */
 interface IBufferLineForUrlProvider {
   length: number;
+  /**
+   * `true` when this line is the continuation of a soft-wrap from the
+   * previous line — i.e. the previous line was wider than `cols` and
+   * spilled here.
+   */
+  isWrapped: boolean;
   getCell(x: number):
     | {
         getCodepoint(): number;

--- a/lib/url-detection.test.ts
+++ b/lib/url-detection.test.ts
@@ -9,23 +9,44 @@ import { describe, expect, test } from 'bun:test';
 import { UrlRegexProvider } from './providers/url-regex-provider';
 import type { ILink } from './types';
 
+interface MockLine {
+  text: string;
+  /** True if this line is the continuation of a soft-wrap from the line above. */
+  isWrapped?: boolean;
+}
+
 /**
- * Mock terminal for testing
+ * Mock terminal supporting one or more buffer lines, each with an
+ * optional `isWrapped` flag. Lines are padded to `cols` so column
+ * indices map 1:1 onto the cell array (matching the real BufferLine).
  */
-function createMockTerminal(lineText: string) {
-  const cells = Array.from(lineText).map((char) => ({
-    getCodepoint: () => char.codePointAt(0) || 0,
-  }));
+function createMockTerminal(lines: MockLine[] | string, cols = 80) {
+  const rows: MockLine[] =
+    typeof lines === 'string' ? [{ text: lines, isWrapped: false }] : lines;
+
+  function makeBufferLine(row: MockLine) {
+    const chars = Array.from(row.text);
+    while (chars.length < cols) chars.push(' ');
+    return {
+      length: cols,
+      isWrapped: row.isWrapped ?? false,
+      getCell: (x: number) => {
+        if (x < 0 || x >= cols) return undefined;
+        const ch = chars[x];
+        return {
+          getCodepoint: () => ch.codePointAt(0) || 0,
+        };
+      },
+    };
+  }
 
   return {
     buffer: {
       active: {
+        length: rows.length,
         getLine: (y: number) => {
-          if (y !== 0) return undefined;
-          return {
-            length: cells.length,
-            getCell: (x: number) => cells[x],
-          };
+          if (y < 0 || y >= rows.length) return undefined;
+          return makeBufferLine(rows[y]);
         },
       },
     },
@@ -33,14 +54,32 @@ function createMockTerminal(lineText: string) {
 }
 
 /**
- * Helper to get links from provider
+ * Helper to get links from provider for a single-row terminal.
  */
 function getLinks(lineText: string): Promise<ILink[] | undefined> {
+  // biome-ignore lint/suspicious/noExplicitAny: matches existing test pattern
   const terminal = createMockTerminal(lineText) as any;
   const provider = new UrlRegexProvider(terminal);
 
   return new Promise((resolve) => {
     provider.provideLinks(0, resolve);
+  });
+}
+
+/**
+ * Helper to get links from a multi-row terminal at a specific row.
+ */
+function getLinksAt(
+  rows: MockLine[],
+  y: number,
+  cols: number,
+): Promise<ILink[] | undefined> {
+  // biome-ignore lint/suspicious/noExplicitAny: matches existing test pattern
+  const terminal = createMockTerminal(rows, cols) as any;
+  const provider = new UrlRegexProvider(terminal);
+
+  return new Promise((resolve) => {
+    provider.provideLinks(y, resolve);
   });
 }
 
@@ -183,5 +222,73 @@ describe('URL Detection', () => {
     expect(links).toBeDefined();
     expect(links?.length).toBe(1);
     expect(links?.[0].text).toContain('magnet:?xt=urn:btih:abc123');
+  });
+});
+
+describe('URL Detection across soft-wrapped rows', () => {
+  test('joins a URL wrapped across two rows and reports it on both rows', async () => {
+    // cols=20 forces wrapping. Continuation row is row 1 (isWrapped=true).
+    const cols = 20;
+    const rows: MockLine[] = [
+      { text: 'visit https://exampl', isWrapped: false },
+      { text: 'e.com/very/long/path here', isWrapped: true },
+    ];
+
+    const linksOnOrigin = await getLinksAt(rows, 0, cols);
+    expect(linksOnOrigin).toBeDefined();
+    expect(linksOnOrigin?.length).toBe(1);
+    expect(linksOnOrigin?.[0].text).toBe('https://example.com/very/long/path');
+    expect(linksOnOrigin?.[0].range.start).toEqual({ x: 6, y: 0 });
+    expect(linksOnOrigin?.[0].range.end.y).toBe(1);
+
+    // Clicking on the continuation row must also surface the full URL.
+    const linksOnContinuation = await getLinksAt(rows, 1, cols);
+    expect(linksOnContinuation).toBeDefined();
+    expect(linksOnContinuation?.length).toBe(1);
+    expect(linksOnContinuation?.[0].text).toBe('https://example.com/very/long/path');
+  });
+
+  test('walks across three wrapped rows', async () => {
+    const cols = 10;
+    const rows: MockLine[] = [
+      { text: 'https://ex', isWrapped: false },
+      { text: 'ample.com/', isWrapped: true },
+      { text: 'deep/path ', isWrapped: true },
+    ];
+
+    const links = await getLinksAt(rows, 2, cols);
+    expect(links).toBeDefined();
+    expect(links?.length).toBe(1);
+    expect(links?.[0].text).toBe('https://example.com/deep/path');
+    expect(links?.[0].range.start).toEqual({ x: 0, y: 0 });
+    expect(links?.[0].range.end.y).toBe(2);
+  });
+
+  test('does not cross a non-continuation boundary', async () => {
+    // A non-wrapped line in the middle separates two chains. Querying
+    // the last row must not include content from the first chain.
+    const cols = 20;
+    const rows: MockLine[] = [
+      { text: 'not wrapped line    ', isWrapped: false },
+      { text: 'see https://example.', isWrapped: false },
+      { text: 'com/foo/bar here    ', isWrapped: true },
+    ];
+
+    const links = await getLinksAt(rows, 2, cols);
+    expect(links).toBeDefined();
+    expect(links?.length).toBe(1);
+    expect(links?.[0].text).toBe('https://example.com/foo/bar');
+  });
+
+  test('does not return links for unrelated rows outside the URL chain', async () => {
+    const cols = 80;
+    const rows: MockLine[] = [
+      { text: 'unrelated output', isWrapped: false },
+      { text: 'see https://example.com/foo', isWrapped: false },
+      { text: 'more output', isWrapped: false },
+    ];
+
+    const links = await getLinksAt(rows, 0, cols);
+    expect(links).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

`UrlRegexProvider` now walks the soft-wrap chain containing the queried row (using `IBufferLine.isWrapped`) before applying the URL regex, so a URL split across two or more rows is detected as a single link no matter which row in the chain the user clicks.

Previously the provider scanned one row at a time and explicitly noted in its own docs that it "does not support multi-line URLs" — a wrapped URL would either appear truncated to the first row's fragment or wouldn't be detected on continuation rows at all (which carry no URL scheme).

The OSC8 provider already supports multi-row links via hyperlink ID; this brings the regex provider to parity.

## Wrap-chain semantics (worth noting on review)

`IBufferLine.isWrapped` is `true` on the **continuation** row (the row that came from soft-wrapping the line above), not on the row that wraps. So a two-row chain looks like:

```
row N:   isWrapped=false  ← logical-line start
row N+1: isWrapped=true   ← continuation
```

To find the chain containing row `y`:
- walk backward from `y` while the **current** row's `isWrapped` is true
- then walk forward from there while the **next** row's `isWrapped` is true

I confirmed the direction at runtime (it's easy to get inverted) before fixing the test mock.

## Implementation

- `lib/providers/url-regex-provider.ts` (+108/−32): wrap-chain walker bounded at 256 rows, joined-string + per-row offset table, regex matches mapped back to `(col, row)` for the multi-row `IBufferRange`. Emitted links are filtered to those whose range intersects the queried row so the `LinkManager` cache stays clean.
- `lib/url-detection.test.ts` (+121/−8): mock terminal helper extended to support multi-row buffers with `isWrapped` flags. Added 4 wrap-chain tests covering: two-row wrap (queried from both rows), three-row wrap, non-continuation boundary, and out-of-chain rows.

## Test plan

- [x] All 20 pre-existing single-line URL detection tests still pass.
- [x] 4 new multi-line tests pass.
- [x] `tsc --noEmit` clean.
- [x] Verified end-to-end against a real terminal: vim-rendered wrapped URL, clicking either origin row or continuation row returns the full URL with the expected multi-row range.