### PR TITLE
fix(input): make Alt+<letter> survive macOS Option composition

### DIFF
--- a/lib/ghostty.ts
+++ b/lib/ghostty.ts
@@ -288,6 +288,13 @@ export class KeyEncoder {
     this.exports.ghostty_key_event_set_action(eventPtr, event.action);
     this.exports.ghostty_key_event_set_key(eventPtr, event.key);
     this.exports.ghostty_key_event_set_mods(eventPtr, event.mods);
+    // Always set unshifted_codepoint (0 when absent) so a stale value from a
+    // previous encode on the cached eventPtr doesn't leak through. The
+    // encoder treats 0 as "not set" and falls back accordingly.
+    this.exports.ghostty_key_event_set_unshifted_codepoint(
+      eventPtr,
+      event.unshiftedCodepoint ?? 0
+    );
 
     // Encode utf8 directly into the WASM scratch buffer with encodeInto,
     // skipping the intermediate Uint8Array that TEXT_ENCODER.encode would

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,7 +79,7 @@ export {
   DirtyState,
   KeyEncoderOption,
 } from './ghostty';
-export { Key, KeyAction, Mods } from './types';
+export { Key, KeyAction, Mods, OptionAsAlt } from './types';
 export type { KeyEvent, GhosttyCell, RGB, Cursor, TerminalHandle } from './types';
 
 // Low-level components (for custom integrations)

--- a/lib/input-handler.test.ts
+++ b/lib/input-handler.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Ghostty } from './ghostty';
 import { InputHandler } from './input-handler';
-import { Key, KeyAction, Mods } from './types';
+import { Key, KeyAction, Mods, TerminalMode } from './types';
 
 // Mock DOM types for testing
 interface MockKeyboardEvent {
@@ -1012,6 +1012,69 @@ describe('InputHandler', () => {
       expect(dataReceived.length).toBe(1);
       // Alt+A often produces ESC a or similar
       expect(dataReceived[0].length).toBeGreaterThan(0);
+    });
+
+    test('Alt+letter emits ESC+letter when alt_esc_prefix (DEC 1036) is on', () => {
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        // getMode callback: turn on alt_esc_prefix, leave others off
+        (mode: number) => mode === TerminalMode.ALT_ESC_PREFIX
+      );
+
+      simulateKey(container, createKeyEvent('KeyB', 'b', { alt: true }));
+
+      expect(dataReceived).toEqual(['\x1bb']);
+    });
+
+    test('macOS Option+letter (composed char in event.key) emits ESC+letter', () => {
+      // On macOS, pressing Option+B in a browser yields event.key='∫' (the
+      // U+222B integral sign), but event.code remains 'KeyB'. Without the
+      // unshifted-codepoint fallback the encoder would write '∫' to the PTY,
+      // silently dropping the Alt shortcut. With the fallback it recovers
+      // the base key and emits ESC+b as expected by readline/editors.
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        (mode: number) => mode === TerminalMode.ALT_ESC_PREFIX
+      );
+
+      simulateKey(container, createKeyEvent('KeyB', '∫', { alt: true }));
+
+      expect(dataReceived).toEqual(['\x1bb']);
+    });
+
+    test('macOS Option+Numpad1 (composed char) emits ESC+1', () => {
+      // macOS Option composition applies to NumLock-on numpad keys too:
+      // Option+Numpad1 → '¡' (U+00A1), code='Numpad1'. Verifies the
+      // Numpad entries in the unshifted-codepoint fallback table.
+      const handler = new InputHandler(
+        ghostty,
+        container as any,
+        (data) => dataReceived.push(data),
+        () => {
+          bellCalled = true;
+        },
+        undefined,
+        undefined,
+        (mode: number) => mode === TerminalMode.ALT_ESC_PREFIX
+      );
+
+      simulateKey(container, createKeyEvent('Numpad1', '¡', { alt: true }));
+
+      expect(dataReceived).toEqual(['\x1b1']);
     });
   });
 

--- a/lib/input-handler.ts
+++ b/lib/input-handler.ts
@@ -16,7 +16,7 @@
 import type { Ghostty } from './ghostty';
 import type { KeyEncoder } from './ghostty';
 import type { IKeyEvent } from './interfaces';
-import { Key, KeyAction, KeyEncoderOption, Mods } from './types';
+import { Key, KeyAction, KeyEncoderOption, Mods, TerminalMode } from './types';
 
 /**
  * Map KeyboardEvent.code values to USB HID Key enum values
@@ -151,6 +151,94 @@ const KEY_MAP: Record<string, Key> = {
   F22: Key.F22,
   F23: Key.F23,
   F24: Key.F24,
+};
+
+/**
+ * US-QWERTY fallback mapping from KeyboardEvent.code to the unshifted ASCII
+ * codepoint the physical key produces on a US layout. Used to populate
+ * `unshiftedCodepoint` on KeyEvent so the Ghostty encoder can recover the
+ * base key when the browser applied a layout-dependent translation to
+ * event.key — most importantly macOS Option composition (Option+B → '∫')
+ * where event.key is the composed character but event.code is still 'KeyB'.
+ *
+ * Without this fallback, Alt+<letter> on macOS silently writes the composed
+ * Unicode character instead of the expected ESC+<letter> that terminal users
+ * rely on for readline/editor bindings.
+ *
+ * Layouts that aren't US-QWERTY produce wrong alt-prefix bytes here; callers
+ * who care about non-QWERTY layouts should set `unshiftedCodepoint` on the
+ * KeyEvent themselves (via attachCustomKeyEventHandler or by calling
+ * KeyEncoder.encode directly).
+ */
+const CODE_TO_UNSHIFTED_CODEPOINT: Record<string, number> = {
+  KeyA: 0x61, // 'a'
+  KeyB: 0x62,
+  KeyC: 0x63,
+  KeyD: 0x64,
+  KeyE: 0x65,
+  KeyF: 0x66,
+  KeyG: 0x67,
+  KeyH: 0x68,
+  KeyI: 0x69,
+  KeyJ: 0x6a,
+  KeyK: 0x6b,
+  KeyL: 0x6c,
+  KeyM: 0x6d,
+  KeyN: 0x6e,
+  KeyO: 0x6f,
+  KeyP: 0x70,
+  KeyQ: 0x71,
+  KeyR: 0x72,
+  KeyS: 0x73,
+  KeyT: 0x74,
+  KeyU: 0x75,
+  KeyV: 0x76,
+  KeyW: 0x77,
+  KeyX: 0x78,
+  KeyY: 0x79,
+  KeyZ: 0x7a,
+  Digit0: 0x30,
+  Digit1: 0x31,
+  Digit2: 0x32,
+  Digit3: 0x33,
+  Digit4: 0x34,
+  Digit5: 0x35,
+  Digit6: 0x36,
+  Digit7: 0x37,
+  Digit8: 0x38,
+  Digit9: 0x39,
+  Minus: 0x2d, // '-'
+  Equal: 0x3d, // '='
+  BracketLeft: 0x5b, // '['
+  BracketRight: 0x5d, // ']'
+  Backslash: 0x5c, // '\'
+  Semicolon: 0x3b, // ';'
+  Quote: 0x27, // "'"
+  Backquote: 0x60, // '`'
+  Comma: 0x2c, // ','
+  Period: 0x2e, // '.'
+  Slash: 0x2f, // '/'
+  Space: 0x20,
+  // Numpad keys — Option composition applies here too on macOS
+  // (e.g. Option+Numpad1 → '¡'), so the fallback recovers '1' for the
+  // alt-prefix path. Mirrors the KEY_MAP Numpad set above; NumpadEnter is
+  // omitted because the encoder has a dedicated function-key path for
+  // Enter and never falls through to a printable byte.
+  Numpad0: 0x30,
+  Numpad1: 0x31,
+  Numpad2: 0x32,
+  Numpad3: 0x33,
+  Numpad4: 0x34,
+  Numpad5: 0x35,
+  Numpad6: 0x36,
+  Numpad7: 0x37,
+  Numpad8: 0x38,
+  Numpad9: 0x39,
+  NumpadDivide: 0x2f, // '/'
+  NumpadMultiply: 0x2a, // '*'
+  NumpadSubtract: 0x2d, // '-'
+  NumpadAdd: 0x2b, // '+'
+  NumpadDecimal: 0x2e, // '.'
 };
 
 /**
@@ -437,14 +525,37 @@ export class InputHandler {
       if (event.key.length === scalarLen) utf8 = event.key;
     }
 
+    // The unshifted codepoint is what the physical key would produce with no
+    // modifiers applied. The encoder uses it as a fallback when utf8 is
+    // either missing or too wide to fit in one byte — e.g. macOS Option+B
+    // gives event.key='∫' (3 UTF-8 bytes), but the user expects ESC+b.
+    // Sourced from a US-QWERTY fallback table keyed on event.code; callers
+    // with non-QWERTY users should override by wrapping InputHandler.
+    const unshiftedCodepoint = CODE_TO_UNSHIFTED_CODEPOINT[event.code];
+
     // Sync encoder options with terminal mode state before every encode.
-    // DEC mode 1 (DECCKM) → cursor-key application mode.
-    // DEC mode 66 (DECNKM) → keypad application mode.
+    // - DECCKM (mode 1)   → cursor-key application mode.
+    // - DECNKM (mode 66)  → keypad application mode.
+    // - alt_esc_prefix (mode 1036) → Alt+<key> encoded as ESC <key>.
+    //   Defaults true in Ghostty; terminal apps disable it to receive
+    //   meta-composed text unchanged. Without this sync, Alt+<letter>
+    //   would never be prefixed with ESC and macOS Option-composed
+    //   characters would reach the PTY verbatim.
     // syncEncoderOption skips the WASM round-trip when the value hasn't
     // changed since last keystroke, which is the common case.
     if (this.getModeCallback) {
-      this.syncEncoderOption(KeyEncoderOption.CURSOR_KEY_APPLICATION, this.getModeCallback(1));
-      this.syncEncoderOption(KeyEncoderOption.KEYPAD_KEY_APPLICATION, this.getModeCallback(66));
+      this.syncEncoderOption(
+        KeyEncoderOption.CURSOR_KEY_APPLICATION,
+        this.getModeCallback(TerminalMode.CURSOR_KEYS)
+      );
+      this.syncEncoderOption(
+        KeyEncoderOption.KEYPAD_KEY_APPLICATION,
+        this.getModeCallback(TerminalMode.KEYPAD_KEYS)
+      );
+      this.syncEncoderOption(
+        KeyEncoderOption.ALT_ESC_PREFIX,
+        this.getModeCallback(TerminalMode.ALT_ESC_PREFIX)
+      );
     }
 
     // mapKeyCode succeeded → we own this key. Prevent browser default
@@ -472,6 +583,7 @@ export class InputHandler {
         key,
         mods,
         utf8,
+        unshiftedCodepoint,
       });
     } catch (error) {
       console.warn('Failed to encode key:', event.code, error);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -112,6 +112,22 @@ export enum KeyEncoderOption {
   ALT_ESC_PREFIX = 3, // DEC mode 1036
   MODIFY_OTHER_KEYS_STATE_2 = 4, // xterm modifyOtherKeys
   KITTY_KEYBOARD_FLAGS = 5, // Kitty protocol flags
+  MACOS_OPTION_AS_ALT = 6, // macOS option-as-alt (value: OptionAsAlt)
+}
+
+/**
+ * macOS option key behavior (for MACOS_OPTION_AS_ALT encoder option).
+ *
+ * Note: the underlying Ghostty encoder only consults this option when built
+ * for macOS. The ghostty-web WASM is built as wasm32-freestanding, so this
+ * field has no effect — Alt is always treated as Alt. The enum is kept in
+ * sync with the C API for documentation and forward compatibility.
+ */
+export enum OptionAsAlt {
+  FALSE = 0,
+  TRUE = 1,
+  LEFT = 2,
+  RIGHT = 3,
 }
 
 /**
@@ -406,6 +422,7 @@ export interface GhosttyWasmExports extends WebAssembly.Exports {
   ghostty_key_event_set_key(event: number, key: number): void;
   ghostty_key_event_set_mods(event: number, mods: number): void;
   ghostty_key_event_set_utf8(event: number, ptr: number, len: number): void;
+  ghostty_key_event_set_unshifted_codepoint(event: number, codepoint: number): void;
 
   // Terminal lifecycle
   ghostty_terminal_new(cols: number, rows: number): TerminalHandle;
@@ -773,11 +790,14 @@ export class EventEmitter<T> {
  * - INSERT = 4
  *
  * DEC modes (use with is_ansi = false):
+ * - CURSOR_KEYS = 1 (DECCKM)
+ * - KEYPAD_KEYS = 66 (DECNKM)
  * - CURSOR_VISIBLE = 25
  * - MOUSE_TRACKING_NORMAL = 1000
  * - MOUSE_TRACKING_BUTTON = 1002
  * - MOUSE_TRACKING_ANY = 1003
  * - FOCUS_EVENTS = 1004
+ * - ALT_ESC_PREFIX = 1036
  * - ALT_SCREEN = 1047
  * - ALT_SCREEN_WITH_CURSOR = 1049
  * - BRACKETED_PASTE = 2004
@@ -787,11 +807,17 @@ export enum TerminalMode {
   INSERT = 4,
 
   // DEC modes
+  /** DECCKM: arrow keys send application-mode sequences (ESC O A) instead of legacy CSI sequences (ESC [ A). */
+  CURSOR_KEYS = 1,
+  /** DECNKM: numeric keypad sends application-mode sequences. */
+  KEYPAD_KEYS = 66,
   CURSOR_VISIBLE = 25,
   MOUSE_TRACKING_NORMAL = 1000,
   MOUSE_TRACKING_BUTTON = 1002,
   MOUSE_TRACKING_ANY = 1003,
   FOCUS_EVENTS = 1004,
+  /** xterm "meta sends escape": Alt+<key> is encoded as ESC <key>. Default on in Ghostty. */
+  ALT_ESC_PREFIX = 1036,
   ALT_SCREEN = 1047,
   ALT_SCREEN_WITH_CURSOR = 1049,
   BRACKETED_PASTE = 2004,


### PR DESCRIPTION
## Summary

On macOS, pressing Option+B in a browser gives `event.key='∫'` (U+222B) while `event.code` is still `'KeyB'`. `InputHandler` was passing the composed character to the Ghostty encoder as `utf8` with no `unshiftedCodepoint`, so `legacyAltPrefix` (which needs either a one-byte `utf8` or a non-zero `unshifted_codepoint`) gave up and `writeAll(utf8)` wrote `∫` straight to the PTY — silently dropping the Alt shortcut readline / editors / shells expect.

Three pieces, all in the encoder path so consumers calling `KeyEncoder.encode` directly also benefit:

1. **Populate `unshiftedCodepoint`** from a US-QWERTY fallback table keyed on `event.code`. The encoder's `legacyAltPrefix` uses it as the base-key fallback when `utf8` is too wide. Non-QWERTY callers can override via `attachCustomKeyEventHandler` or by calling `KeyEncoder.encode` directly.
2. **Sync DEC mode 1036 (`alt_esc_prefix`)** onto the encoder alongside the existing cursor-key / keypad mode syncs. Without this, `alt_esc_prefix` stays at its default `false` and `legacyAltPrefix` returns null regardless. Mode 1036 defaults to true in Ghostty's terminal, and apps that want Option-composed text reaching them can disable the mode the usual way.
3. **Forward `unshiftedCodepoint`** through `KeyEncoder.encode()` to the existing `ghostty_key_event_set_unshifted_codepoint` export. WASM unchanged.

Also exposes `KeyEncoderOption.MACOS_OPTION_AS_ALT` and an `OptionAsAlt` enum for parity with the C ABI. The WASM build is `wasm32-freestanding`, so the encoder's `comptime builtin.os.tag == .macos` guard on `macos_option_as_alt` is never taken — the option is a no-op at runtime today, but exposing it keeps the TypeScript surface aligned for when a darwin WASM target appears.

## Tests

Two new cases in `lib/input-handler.test.ts`:

- Linux Alt+B (`event.key='b'`) → `ESC b` with mode 1036 on
- macOS Option+B (`event.key='∫'`) → `ESC b` with mode 1036 on

`bun test`: 354 → 357 pass.
`bun run typecheck`: clean.

## Browser-runtime verification

Built `lib`, dropped the bundle into a host app, and exercised the encoder end-to-end:

| Case | Bytes | Result |
|------|-------|--------|
| Linux Alt+B (utf8='b', unshifted=0x62) | `1b 62` | ESC+b ✓ |
| macOS Option+B (utf8='∫', unshifted=0x62) | `1b 62` | ESC+b ✓ (the fix) |
| Plain b | `62` | b ✓ (no regression) |
| Alt+B without unshifted fallback | `e2 88 ab` | ∫ — confirms the pre-fix path |

🤖 Generated with [Claude Code](https://claude.com/claude-code)