### PR TITLE
chore(lint): allow hex codepoint keys in renderer.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -39,5 +39,17 @@
   },
   "files": {
     "ignore": ["node_modules", "dist", "coverage", "*.wasm", ".git", ".vite", "bun.lock"]
-  }
+  },
+  "overrides": [
+    {
+      "include": ["lib/renderer.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "useSimpleNumberKeys": "off"
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
biome's useSimpleNumberKeys rule rejects hexadecimal object-literal keys and is fixable only by converting them to decimal. The quadMap in lib/renderer.ts uses keys like 0x2598..0x259f because they are Unicode codepoints, where hex is the canonical form (matches the U+xxxx notation used in Unicode docs and the surrounding code).

Scope the override to lib/renderer.ts so the rule continues to apply everywhere else.