### PR TITLE
chore(fmt): prettier --write pass

### DIFF
--- a/lib/box-drawing.test.ts
+++ b/lib/box-drawing.test.ts
@@ -27,7 +27,15 @@ type Op =
   | { kind: 'beginPath' }
   | { kind: 'moveTo'; x: number; y: number }
   | { kind: 'lineTo'; x: number; y: number }
-  | { kind: 'bezierCurveTo'; cp1x: number; cp1y: number; cp2x: number; cp2y: number; x: number; y: number }
+  | {
+      kind: 'bezierCurveTo';
+      cp1x: number;
+      cp1y: number;
+      cp2x: number;
+      cp2y: number;
+      x: number;
+      y: number;
+    }
   | { kind: 'stroke' }
   | { kind: 'translate'; x: number; y: number };
 
@@ -45,14 +53,7 @@ interface RecordingCtx {
   beginPath(): void;
   moveTo(x: number, y: number): void;
   lineTo(x: number, y: number): void;
-  bezierCurveTo(
-    cp1x: number,
-    cp1y: number,
-    cp2x: number,
-    cp2y: number,
-    x: number,
-    y: number
-  ): void;
+  bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
   stroke(): void;
   translate(x: number, y: number): void;
 }
@@ -188,9 +189,7 @@ describe('box-drawing', () => {
         // fillRect would slip through the looser `o.kind === ...`
         // check.
         const drewSomething = ctx.ops.some(
-          (o) =>
-            (o.kind === 'fillRect' && o.w > 0 && o.h > 0) ||
-            o.kind === 'stroke'
+          (o) => (o.kind === 'fillRect' && o.w > 0 && o.h > 0) || o.kind === 'stroke'
         );
         if (!handled || !drewSomething) missing.push(cp);
       }

--- a/lib/ghostty.ts
+++ b/lib/ghostty.ts
@@ -319,10 +319,7 @@ export class KeyEncoder {
     // Always set unshifted_codepoint (0 when absent) so a stale value from a
     // previous encode on the cached eventPtr doesn't leak through. The
     // encoder treats 0 as "not set" and falls back accordingly.
-    this.exports.ghostty_key_event_set_unshifted_codepoint(
-      eventPtr,
-      event.unshiftedCodepoint ?? 0
-    );
+    this.exports.ghostty_key_event_set_unshifted_codepoint(eventPtr, event.unshiftedCodepoint ?? 0);
 
     // Encode utf8 directly into the WASM scratch buffer with encodeInto,
     // skipping the intermediate Uint8Array that TEXT_ENCODER.encode would

--- a/lib/providers/url-regex-provider.ts
+++ b/lib/providers/url-regex-provider.ts
@@ -84,10 +84,7 @@ export class UrlRegexProvider implements ILinkProvider {
     // Walk forward to the end of the chain by extending while the *next*
     // row is a continuation.
     let endRow = startRow;
-    while (
-      endRow - startRow < UrlRegexProvider.MAX_WRAP_CHAIN_ROWS &&
-      endRow < buffer.length - 1
-    ) {
+    while (endRow - startRow < UrlRegexProvider.MAX_WRAP_CHAIN_ROWS && endRow < buffer.length - 1) {
       const next = buffer.getLine(endRow + 1);
       if (!next || !next.isWrapped) break;
       endRow++;
@@ -185,7 +182,7 @@ export class UrlRegexProvider implements ILinkProvider {
   private joinedIdxToRowCol(
     joinedIdx: number,
     rowStartIdx: number[],
-    baseRow: number,
+    baseRow: number
   ): { x: number; y: number } {
     for (let i = rowStartIdx.length - 1; i >= 0; i--) {
       if (joinedIdx >= rowStartIdx[i]) {

--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -808,7 +808,7 @@ export class CanvasRenderer {
     // we cannot infer it from the RGB triple because (0,0,0) is a valid
     // explicit color (programs emit it for "true black" backgrounds, e.g.
     // letterboxed image renderings).
-    const useThemeBg = (cell.flags & CellFlags.INVERSE) ? cell.fgIsDefault : cell.bgIsDefault;
+    const useThemeBg = cell.flags & CellFlags.INVERSE ? cell.fgIsDefault : cell.bgIsDefault;
     if (!useThemeBg) {
       this.ctx.fillStyle = this.rgbToCSS(bg_r, bg_g, bg_b);
       this.ctx.fillRect(cellX, cellY, cellWidth, this.metrics.height);
@@ -873,7 +873,7 @@ export class CanvasRenderer {
       // Same reasoning as the bg path: only fall back to theme.foreground
       // when the cell has the default fg (tag NONE), not when its explicit
       // RGB happens to be (0,0,0).
-      const useThemeFg = (cell.flags & CellFlags.INVERSE) ? cell.bgIsDefault : cell.fgIsDefault;
+      const useThemeFg = cell.flags & CellFlags.INVERSE ? cell.bgIsDefault : cell.fgIsDefault;
       this.ctx.fillStyle = useThemeFg ? this.theme.foreground : this.rgbToCSS(fg_r, fg_g, fg_b);
     }
 
@@ -1213,8 +1213,7 @@ export class CanvasRenderer {
     if (quads & QUAD_UL) this.ctx.fillRect(cellX, cellY, halfW, halfH);
     if (quads & QUAD_UR) this.ctx.fillRect(cellX + halfW, cellY, w - halfW, halfH);
     if (quads & QUAD_LL) this.ctx.fillRect(cellX, cellY + halfH, halfW, h - halfH);
-    if (quads & QUAD_LR)
-      this.ctx.fillRect(cellX + halfW, cellY + halfH, w - halfW, h - halfH);
+    if (quads & QUAD_LR) this.ctx.fillRect(cellX + halfW, cellY + halfH, w - halfW, h - halfH);
     return true;
   }
 

--- a/lib/selection-manager.ts
+++ b/lib/selection-manager.ts
@@ -125,10 +125,7 @@ export class SelectionManager {
     renderer: CanvasRenderer,
     wasmTerm: GhosttyTerminal,
     textarea: HTMLTextAreaElement,
-    onLongPressActivation?: (
-      col: number,
-      absoluteRow: number
-    ) => Promise<boolean> | boolean
+    onLongPressActivation?: (col: number, absoluteRow: number) => Promise<boolean> | boolean
   ) {
     this.terminal = terminal;
     this.renderer = renderer;

--- a/lib/terminal.test.ts
+++ b/lib/terminal.test.ts
@@ -3029,9 +3029,9 @@ describe('Synchronous open()', () => {
     const wasmTerm1 = term1.wasmTerm!;
 
     // Write multi-codepoint grapheme clusters (flag emoji, skin tone, ZWJ sequence)
-    wasmTerm1.write('\u{1F1FA}\u{1F1F8}');  // 🇺🇸 regional indicator pair
-    wasmTerm1.write('\u{1F44B}\u{1F3FD}');  // 👋🏽 wave + skin tone modifier
-    wasmTerm1.write('\u{1F468}\u200D\u{1F469}\u200D\u{1F467}');  // 👨‍👩‍👧 ZWJ family
+    wasmTerm1.write('\u{1F1FA}\u{1F1F8}'); // 🇺🇸 regional indicator pair
+    wasmTerm1.write('\u{1F44B}\u{1F3FD}'); // 👋🏽 wave + skin tone modifier
+    wasmTerm1.write('\u{1F468}\u200D\u{1F469}\u200D\u{1F467}'); // 👨‍👩‍👧 ZWJ family
 
     // Free the terminal that processed grapheme clusters
     wasmTerm1.free();

--- a/lib/terminal.ts
+++ b/lib/terminal.ts
@@ -573,7 +573,6 @@ export class Terminal implements ITerminalCore {
       // row iterator immediately after open() and rely on the second
       // update() / clearDirty pair to settle WASM state.
       this.renderTick();
-
     } catch (error) {
       // Clean up on error
       this.isOpen = false;

--- a/lib/url-detection.test.ts
+++ b/lib/url-detection.test.ts
@@ -21,8 +21,7 @@ interface MockLine {
  * indices map 1:1 onto the cell array (matching the real BufferLine).
  */
 function createMockTerminal(lines: MockLine[] | string, cols = 80) {
-  const rows: MockLine[] =
-    typeof lines === 'string' ? [{ text: lines, isWrapped: false }] : lines;
+  const rows: MockLine[] = typeof lines === 'string' ? [{ text: lines, isWrapped: false }] : lines;
 
   function makeBufferLine(row: MockLine) {
     const chars = Array.from(row.text);
@@ -69,11 +68,7 @@ function getLinks(lineText: string): Promise<ILink[] | undefined> {
 /**
  * Helper to get links from a multi-row terminal at a specific row.
  */
-function getLinksAt(
-  rows: MockLine[],
-  y: number,
-  cols: number,
-): Promise<ILink[] | undefined> {
+function getLinksAt(rows: MockLine[], y: number, cols: number): Promise<ILink[] | undefined> {
   // biome-ignore lint/suspicious/noExplicitAny: matches existing test pattern
   const terminal = createMockTerminal(rows, cols) as any;
   const provider = new UrlRegexProvider(terminal);


### PR DESCRIPTION
Eight files drifted from prettier formatting and bun run fmt was failing on main. The changes are purely cosmetic — collapsing/expanding lines around prettier's width limit and dropping redundant parens. No behavior changes.

Unblocks the fmt check on main.