### PR TITLE
ci: run lint/fmt/typecheck through hk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Run hk check
-        run: hk check --all
+        run: hk check --all --slow
 
   test:
     name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  fmt:
-    name: fmt
+  check:
+    name: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -17,43 +17,16 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Install dependencies
-        run: bun install
-
-      - name: Check formatting
-        run: bun run fmt
-
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      - uses: jdx/mise-action@v3
 
       - name: Install dependencies
         run: bun install
 
-      - name: Run linter
-        run: bun run lint
+      - name: Add node_modules/.bin to PATH
+        run: echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
 
-  typecheck:
-    name: type check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Check types
-        run: bun run typecheck
+      - name: Run hk check
+        run: hk check --all
 
   test:
     name: test

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,23 @@
+amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+    ["prettier"] = Builtins.prettier
+    ["biome"] = Builtins.biome
+    ["tsc"] = Builtins.tsc
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = linters
+    }
+    ["fix"] {
+        fix = true
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+}

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,7 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtin
 local linters = new Mapping<String, Step> {
     ["prettier"] = Builtins.prettier
     ["biome"] = Builtins.biome
-    ["tsc"] = Builtins.tsc
+    ["tsc"] = (Builtins.tsc) { profiles = List("slow") }
 }
 
 hooks {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+"github:jdx/hk" = "1.45.0"
+pkl = "0.31.1"


### PR DESCRIPTION
Adds an hk.pkl wiring up the prettier, biome, and tsc builtins so the same checks run locally (pre-commit, fix, check hooks) and in CI.

Pins hk + pkl via mise.toml and collapses the separate fmt/lint/typecheck CI jobs into a single `check` job that invokes `hk check --all`.